### PR TITLE
fix ble bug and compatible with the use cases from the documentation

### DIFF
--- a/demo/runner.ipynb
+++ b/demo/runner.ipynb
@@ -33,8 +33,8 @@
     "    await ev3.connect('192.168.133.101')\n",
     "    \n",
     "    hub = BLEPUPConnection()\n",
-    "    address = await find_device('Pybricks Hub', timeout=5)\n",
-    "    await hub.connect(address)\n",
+    "    device = await find_device('Pybricks Hub', timeout=5)\n",
+    "    await hub.connect(device.address)\n",
     "    \n"
    ]
   },

--- a/pybricksdev/ble.py
+++ b/pybricksdev/ble.py
@@ -103,7 +103,7 @@ class BLEConnection():
         """
 
         print("Connecting to", device)
-        self.client = BleakClient(device)
+        self.client = BleakClient(device.address)
         await self.client.connect(disconnected_callback=self.disconnected_handler)
         await self.client.start_notify(self.char_tx_UUID, self.data_handler)
         print("Connected successfully!")

--- a/pybricksdev/ble.py
+++ b/pybricksdev/ble.py
@@ -9,16 +9,16 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
 
-async def find_device(name: str, timeout: float = 5) -> BLEDevice:
-    """Quickly find BLE device address by friendly device name.
+async def find_device(device_or_address: str, timeout: float = 5) -> BLEDevice:
+    """Quickly find BLE device address by friendly device name or address.
 
     This is an alternative to bleak.discover. Instead of waiting a long time to
     scan everything, it returns as soon as it finds any device with the
     requested name.
 
     Arguments:
-        name (str):
-            Friendly device name.
+        device_or_address (str):
+            Friendly device name or address.
         timeout (float):
             When to give up searching.
 
@@ -29,14 +29,15 @@ async def find_device(name: str, timeout: float = 5) -> BLEDevice:
         asyncio.TimeoutError:
             Device was not found within the timeout.
     """
-    print("Searching for {0}".format(name))
+    print("Searching for {0}".format(device_or_address))
 
     queue = asyncio.Queue()
 
     def set_device_discovered(device: BLEDevice, _: AdvertisementData):
-        if device.name != name:
+        if device_or_address in [device.name, device.address]:
+            queue.put_nowait(device)
+        else:
             return
-        queue.put_nowait(device)
 
     async with BleakScanner(detection_callback=set_device_discovered):
         return await asyncio.wait_for(queue.get(), timeout=timeout)

--- a/pybricksdev/connections.py
+++ b/pybricksdev/connections.py
@@ -723,7 +723,7 @@ class PybricksHub:
             RuntimeError: if Pybricks Protocol version is not supported
         """
         self.logger.info(f"Connecting to {device.address}")
-        self.client = BleakClient(device)
+        self.client = BleakClient(device.address)
 
         def disconnected_handler(self, _: BleakClient):
             self.logger.info("Disconnected!")


### PR DESCRIPTION
 use cases from the [documentation](https://github.com/pybricks/pybricksdev#running-pybricks-micropython-programs):

```bash
# Run script on the first device we find called Pybricks hub
pybricksdev run ble "Pybricks Hub" demo/shortdemo.py

# Run script on device with address 90:84:2B:4A:2B:75 (doesn't work on Mac)
pybricksdev run ble 90:84:2B:4A:2B:75 demo/shortdemo.py
```

 work on Mac!