### PR TITLE
connections: Fixed premature program termination

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,8 @@ file in the project when you select the interpreter.
 For instance, if you want the installed `pybricksdev` to use code from the `develop` branch of the `bleak` package.
 
     pipx inject pybricksdev https://github.com/hbldh/bleak/archive/refs/heads/develop.zip
+                   
+### Make sure the code style and formatting are correct
+
+    poetry run flake8 --show-source
+    poetry run black .


### PR DESCRIPTION
Fixes #28.
1. The `user_program_stopped` flag is set only when the program state changes from `True -> False`. Prevents premature program termination when the `pybricks_service_handler` is invoked, and the program was loaded but not yet running.
2. Inverted the `loading` property to `program_loaded` to avoid `pybricks_service_handler` setting the `user_program_stopped` flag before the program loading starts.
3. The `pybricks_service_handler` decodes data only if the program is loaded.
4. Added `__` prefix for internal functions.