### PR TITLE
Multi-file projects (Importing modules, take 3)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "args": [
                 "run",
                 "ble",
-                "${workspaceFolder}/demo/shortdemo.py"
+                "${workspaceFolder}/demo/multidemo.py"
             ]
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `fw_version` attribute to `pybricksdev.connections.pybricks.PybricksHub`.
+- Experimental support for multi-file projects.
 
 ### Fixed
 - Fixed running programs on hubs with firmware with MPY ABI v5.

--- a/demo/module1.py
+++ b/demo/module1.py
@@ -1,0 +1,8 @@
+from pybricks.parameters import Color
+
+nice_color = Color.GREEN
+
+print("I am", __name__)
+
+if __name__ == "__main__":
+    print("module1 is main")

--- a/demo/module2.py
+++ b/demo/module2.py
@@ -1,0 +1,7 @@
+from module1 import nice_color
+
+print("I am", __name__)
+print(nice_color)
+
+if __name__ == "__main__":
+    print("module 2 is main")

--- a/demo/multidemo.py
+++ b/demo/multidemo.py
@@ -1,0 +1,11 @@
+from pybricks.hubs import ThisHub
+from pybricks.parameters import Color
+from pybricks.tools import wait
+from module2 import nice_color
+
+hub = ThisHub()
+hub.light.on(Color.RED)
+wait(2000)
+print("I am", __name__)
+hub.light.on(nice_color)
+wait(2000)

--- a/pybricksdev/connections/pybricks.py
+++ b/pybricksdev/connections/pybricks.py
@@ -28,7 +28,7 @@ from ..ble.pybricks import (
     StatusFlag,
     unpack_pnp_id,
 )
-from ..compile import compile_file
+from ..compile import compile_multi_file
 from ..tools import chunk
 from ..tools.checksum import xor_bytes
 
@@ -264,7 +264,7 @@ class PybricksHub:
 
         # Compile the script to mpy format
         self.script_dir, _ = os.path.split(py_path)
-        mpy = await compile_file(py_path, self._mpy_abi_version)
+        mpy = await compile_multi_file(py_path, self._mpy_abi_version)
 
         try:
             self.loading = True


### PR DESCRIPTION
This makes use of recent experimental firmware changes (https://github.com/pybricks/pybricks-micropython/pull/106) to allow the main script to import modules in the same folder. The modules can also import other modules. To ensure a smooth transition until a firmware with this feature is released, scripts without local imports will be downloaded in the old format (a single raw mpy data blob).

Unlike in #33, there is no special filtering done on the modules this time. They are imported as real modules, and only when the import statements are run.

Quick example of what works:

![image](https://user-images.githubusercontent.com/12326241/183744262-d81c8300-f543-4de9-bf93-a952812bc31a.png)
