### PR TITLE
pybricks/connections/pybricks: add output observable

### DIFF
--- a/pybricksdev/connections/pybricks.py
+++ b/pybricksdev/connections/pybricks.py
@@ -79,6 +79,7 @@ class PybricksHub:
         self.disconnect_observable = AsyncSubject()
         self.status_observable = BehaviorSubject(StatusFlag(0))
         self.nus_observable = Subject()
+        self.output_observable = Subject()
         self.stream_buf = bytearray()
         self.output = []
         self.print_output = True
@@ -135,15 +136,19 @@ class PybricksHub:
             self.log_file = None
             return
 
+        decoded_line = line.decode()
+
         # If we are processing datalog, save current line to the open file.
         if self.log_file is not None:
-            print(line.decode(), file=self.log_file)
+            print(decoded_line, file=self.log_file)
             return
 
-        # If there is nothing special about this line, print it if requested.
+        # If there is nothing special about this line, make it accessible to
+        # users and print it if requested.
         self.output.append(line)
+        self.output_observable.on_next(decoded_line)
         if self.print_output:
-            print(line.decode())
+            print(decoded_line)
 
     def nus_handler(self, sender, data):
         self.nus_observable.on_next(data)


### PR DESCRIPTION
I went ahead and added an observable `PybricksHub.output_observable` that notifies subscribers when a new line arrives from the hub, as proposed in https://github.com/pybricks/support/discussions/652#discussioncomment-2754761

Tested like this:
```python
import asyncio

from pybricksdev.connections.pybricks import PybricksHub
from pybricksdev.ble import find_device

hub = PybricksHub()

async def main():
    dev = await find_device()
    await hub.connect(dev)

    def handle_output(line):
        print("received:", line.decode())

    try:
        with hub.output_observable.subscribe(handle_output):
            await hub.run("hub_messages.py", print_output=False)
    finally:
        await hub.disconnect()


asyncio.run(main())
```

Another step might be to add `PybricksHub.output_queue` which is an `asyncio.Queue`. This would make it possible to receive the lines easily from coroutines. If that makes sense then I can add it as well. Though with the new observable it can be implemented by users quite easily.