### PR TITLE
pybricks/connections/pybricks: add connection context manager

### DIFF
--- a/pybricksdev/connections/pybricks.py
+++ b/pybricksdev/connections/pybricks.py
@@ -255,7 +255,7 @@ class PybricksHub:
             )
             self.connected = True
         except:  # noqa: E722
-            self.disconnect()
+            await self.disconnect()
             raise
 
     async def disconnect(self):


### PR DESCRIPTION
added ``PybricksHub.connection(device)`` async context manager to be used like this:
```python
    dev = await find_device()
    async with hub.connection(dev):
        await hub.run("hub_messages.py")
```
In master, you would write:
```python
    dev = await find_device()
    try:
        await hub.connect(dev)
        await hub.run("hub_messages.py")
    finally:
        await hub.disconnect()
```