### PR TITLE
pybricksdev/compile.py: Add better error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use relative paths when compiling multi-file projects.
+- Better error message when hitting Python bug when compiling multi-file projects.
 
 ## [1.0.0-alpha.48] - 2024-05-04
 

--- a/pybricksdev/compile.py
+++ b/pybricksdev/compile.py
@@ -116,7 +116,13 @@ async def compile_multi_file(path: str, abi: Union[int, Tuple[int, int]]):
     # compile files using Python to find imports contained within the same directory as path
     search_path = [os.path.dirname(path)]
     finder = ModuleFinder(search_path)
-    finder.run_script(path)
+
+    try:
+        finder.run_script(path)
+    except AttributeError as e:
+        raise RuntimeError(
+            "ModuleFinder doesn't currently handle implicit namespace packages. Did you forget to put an __init__.py file in one of your subdirectories? See https://github.com/pybricks/support/issues/1602"
+        ) from e
 
     # we expect missing modules, namely builtin MicroPython packages like pybricks.*
     logger.debug("missing modules: %r", finder.any_missing())


### PR DESCRIPTION
When compiling multi-file projects that contain a namespace pacakge (folder without __init__.py), we hit Python bug python/cpython#84530.

This adds a try/except block to catch the error and raise a more helpful error message.

Issue: https://github.com/pybricks/support/issues/1602