### PR TITLE
connections.ev3: Improve firmware update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.51] - 2024-11-01
+
 ### Added
 - Added `pybricksdev oad info` command.
 - Added `pybricksdev oad flash` command.
+
+### Fixed
+- Fixed EV3 firmware flashing on USB 3.0 systems.
 
 ## [1.0.0-alpha.50] - 2024-07-01
 


### PR DESCRIPTION
- Allow faster flashing of smaller firmwares by erasing only as much as needed.
- Work around USB3.0 issues with the EV3 bootloader. Thanks @JakubVanek for notes in [this issue](https://github.com/c4ev3/ev3duder/issues/32)!

Since all of the changes could be done without any low level hacking of the HID API, this is very promising for when we make a web-based version in the future.

Changes have not been tested on a USB2.0 system yet, but there should be no changes.

Tested on a copy of the official firmware (16MiB).

And on a 1.5MiB Pybricks firmware, which now takes about 6 seconds to erase and 6 seconds to install, instead of up to two minutes or more.

