### PR TITLE
Add a new CLI command push for uploading program without running it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `pybricksdev download` command to download Python scripts to hubs without running them.
+  Supports BLE, USB, and SSH connections. ([pybricksdev#107])
+
+[pybricksdev#107]: https://github.com/pybricks/pybricksdev/issues/107
+
 ## [1.0.1] - 2025-02-20
 
 ### Fixed

--- a/pybricksdev/cli/__init__.py
+++ b/pybricksdev/cli/__init__.py
@@ -325,21 +325,7 @@ class Download(Tool):
         await hub.connect()
         try:
             with _get_script_path(args.file) as script_path:
-                # For PybricksHub, we use download_user_program to just upload without running
-                if args.conntype in ["ble", "usb"]:
-                    from pybricksdev.compile import compile_multi_file
-
-                    # Compile the script to mpy format
-                    mpy = await compile_multi_file(
-                        script_path, hub._mpy_abi_version or 6
-                    )
-                    # Upload without running
-                    await hub.download_user_program(mpy)
-                # For EV3Connection, we just use download
-                elif args.conntype == "ssh":
-                    await hub.download(script_path)
-                else:
-                    raise RuntimeError("Unsupported hub type for download command")
+                await hub.download(script_path)
         finally:
             await hub.disconnect()
 

--- a/pybricksdev/cli/__init__.py
+++ b/pybricksdev/cli/__init__.py
@@ -236,10 +236,10 @@ class Run(Tool):
             await hub.disconnect()
 
 
-class Push(Tool):
+class Download(Tool):
     def add_parser(self, subparsers: argparse._SubParsersAction):
         parser = subparsers.add_parser(
-            "push",
+            "download",
             help="upload a Pybricks program without running it",
         )
         parser.tool = self
@@ -339,7 +339,7 @@ class Push(Tool):
                 elif args.conntype == "ssh":
                     await hub.download(script_path)
                 else:
-                    raise RuntimeError("Unsupported hub type for push command")
+                    raise RuntimeError("Unsupported hub type for download command")
         finally:
             await hub.disconnect()
 
@@ -567,7 +567,7 @@ def main():
         help="the tool to use",
     )
 
-    for tool in Compile(), Run(), Push(), Flash(), DFU(), OAD(), LWP3(), Udev():
+    for tool in Compile(), Run(), Download(), Flash(), DFU(), OAD(), LWP3(), Udev():
         tool.add_parser(subparsers)
 
     argcomplete.autocomplete(parser)

--- a/tests/connections/test_pybricks.py
+++ b/tests/connections/test_pybricks.py
@@ -1,0 +1,167 @@
+"""Tests for the pybricks connection module."""
+
+import asyncio
+import tempfile
+from unittest.mock import AsyncMock, PropertyMock
+
+import pytest
+from reactivex.subject import Subject
+
+from pybricksdev.connections.pybricks import (
+    ConnectionState,
+    HubCapabilityFlag,
+    HubKind,
+    PybricksHubBLE,
+    StatusFlag,
+)
+
+
+class TestPybricksHub:
+    """Tests for the PybricksHub base class functionality."""
+
+    @pytest.mark.asyncio
+    async def test_download_modern_protocol(self):
+        """Test downloading with modern protocol and capability flags."""
+        hub = PybricksHubBLE("mock_device")
+        hub._mpy_abi_version = 6
+        hub._client = AsyncMock()
+        hub.get_capabilities = AsyncMock(return_value={"pybricks": {"mpy": True}})
+        hub.download_user_program = AsyncMock()
+        type(hub.connection_state_observable).value = PropertyMock(
+            return_value=ConnectionState.CONNECTED
+        )
+        hub._capability_flags = HubCapabilityFlag.USER_PROG_MULTI_FILE_MPY6
+
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+            temp.write("print('test')")
+            temp_path = temp.name
+        try:
+            await hub.download(temp_path)
+            hub.download_user_program.assert_called_once()
+        finally:
+            import os
+
+            os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_download_legacy_firmware(self):
+        """Test downloading with legacy firmware."""
+        hub = PybricksHubBLE("mock_device")
+        hub._mpy_abi_version = None  # Legacy firmware
+        hub._client = AsyncMock()
+        hub.download_user_program = AsyncMock()
+        hub.hub_kind = HubKind.BOOST
+        type(hub.connection_state_observable).value = PropertyMock(
+            return_value=ConnectionState.CONNECTED
+        )
+        hub._capability_flags = HubCapabilityFlag.USER_PROG_MULTI_FILE_MPY6
+
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+            temp.write("print('test')")
+            temp_path = temp.name
+        try:
+            await hub.download(temp_path)
+            hub.download_user_program.assert_called_once()
+        finally:
+            import os
+
+            os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_download_unsupported_capabilities(self):
+        """Test downloading when hub doesn't support required capabilities."""
+        hub = PybricksHubBLE("mock_device")
+        hub._mpy_abi_version = 6
+        hub._client = AsyncMock()
+        hub.get_capabilities = AsyncMock(return_value={"pybricks": {"mpy": False}})
+        type(hub.connection_state_observable).value = PropertyMock(
+            return_value=ConnectionState.CONNECTED
+        )
+        hub._capability_flags = 0
+
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+            temp.write("print('test')")
+            temp_path = temp.name
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match="Hub is not compatible with any of the supported file formats",
+            ):
+                await hub.download(temp_path)
+        finally:
+            import os
+
+            os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_download_compile_error(self):
+        """Test handling compilation errors."""
+        hub = PybricksHubBLE("mock_device")
+        hub._mpy_abi_version = 6
+        hub._client = AsyncMock()
+        hub.get_capabilities = AsyncMock(return_value={"pybricks": {"mpy": True}})
+        type(hub.connection_state_observable).value = PropertyMock(
+            return_value=ConnectionState.CONNECTED
+        )
+        hub._capability_flags = HubCapabilityFlag.USER_PROG_MULTI_FILE_MPY6
+
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+            temp.write("print('test'  # Missing closing parenthesis")
+            temp_path = temp.name
+        try:
+            with pytest.raises(SyntaxError):
+                await hub.download(temp_path)
+        finally:
+            import os
+
+            os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_run_modern_protocol(self):
+        """Test running a program with modern protocol."""
+        hub = PybricksHubBLE("mock_device")
+        hub._mpy_abi_version = None  # Use modern protocol
+        hub._client = AsyncMock()
+        hub.client = AsyncMock()
+        hub.get_capabilities = AsyncMock(return_value={"pybricks": {"mpy": True}})
+        hub.download_user_program = AsyncMock()
+        hub.start_user_program = AsyncMock()
+        hub.write_gatt_char = AsyncMock()
+        type(hub.connection_state_observable).value = PropertyMock(
+            return_value=ConnectionState.CONNECTED
+        )
+        hub._capability_flags = HubCapabilityFlag.USER_PROG_MULTI_FILE_MPY6
+        hub.hub_kind = HubKind.BOOST
+
+        # Mock the status observable to simulate program start and stop
+        status_subject = Subject()
+        hub.status_observable = status_subject
+        hub._stdout_line_queue = asyncio.Queue()
+        hub._enable_line_handler = True
+
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+            temp.write("print('test')")
+            temp_path = temp.name
+        try:
+            # Start the run task
+            run_task = asyncio.create_task(hub.run(temp_path))
+
+            # Simulate program start
+            await asyncio.sleep(0.1)
+            status_subject.on_next(StatusFlag.USER_PROGRAM_RUNNING)
+
+            # Simulate program stop after a short delay
+            await asyncio.sleep(0.1)
+            status_subject.on_next(0)  # Clear all flags
+
+            # Wait for run task to complete
+            await run_task
+
+            # Verify the expected calls were made
+            hub.download_user_program.assert_called_once()
+            hub.start_user_program.assert_called_once()
+        finally:
+            import os
+
+            os.unlink(temp_path)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,12 +67,16 @@ class TestDownload:
         mock_hub._mpy_abi_version = 6
         mock_hub.download = AsyncMock()
 
-        # Create a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+        # Set up mocks using ExitStack
+        with contextlib.ExitStack() as stack:
+            # Create and manage temporary file
+            temp = stack.enter_context(
+                tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False)
+            )
             temp.write("print('test')")
             temp_path = temp.name
+            stack.callback(os.unlink, temp_path)
 
-        try:
             # Create args
             args = argparse.Namespace(
                 conntype="ble",
@@ -80,29 +84,25 @@ class TestDownload:
                 name="MyHub",
             )
 
-            # Set up mocks using ExitStack
-            with contextlib.ExitStack() as stack:
-                mock_hub_class = stack.enter_context(
-                    patch(
-                        "pybricksdev.connections.pybricks.PybricksHubBLE",
-                        return_value=mock_hub,
-                    )
+            mock_hub_class = stack.enter_context(
+                patch(
+                    "pybricksdev.connections.pybricks.PybricksHubBLE",
+                    return_value=mock_hub,
                 )
-                stack.enter_context(
-                    patch("pybricksdev.ble.find_device", return_value="mock_device")
-                )
+            )
+            stack.enter_context(
+                patch("pybricksdev.ble.find_device", return_value="mock_device")
+            )
 
-                # Run the command
-                download = Download()
-                await download.run(args)
+            # Run the command
+            download = Download()
+            await download.run(args)
 
-                # Verify the hub was created and used correctly
-                mock_hub_class.assert_called_once_with("mock_device")
-                mock_hub.connect.assert_called_once()
-                mock_hub.download.assert_called_once()
-                mock_hub.disconnect.assert_called_once()
-        finally:
-            os.unlink(temp_path)
+            # Verify the hub was created and used correctly
+            mock_hub_class.assert_called_once_with("mock_device")
+            mock_hub.connect.assert_called_once()
+            mock_hub.download.assert_called_once()
+            mock_hub.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_download_usb(self):
@@ -112,12 +112,16 @@ class TestDownload:
         mock_hub._mpy_abi_version = 6
         mock_hub.download = AsyncMock()
 
-        # Create a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+        # Set up mocks using ExitStack
+        with contextlib.ExitStack() as stack:
+            # Create and manage temporary file
+            temp = stack.enter_context(
+                tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False)
+            )
             temp.write("print('test')")
             temp_path = temp.name
+            stack.callback(os.unlink, temp_path)
 
-        try:
             # Create args
             args = argparse.Namespace(
                 conntype="usb",
@@ -125,27 +129,23 @@ class TestDownload:
                 name=None,
             )
 
-            # Set up mocks using ExitStack
-            with contextlib.ExitStack() as stack:
-                mock_hub_class = stack.enter_context(
-                    patch(
-                        "pybricksdev.connections.pybricks.PybricksHubUSB",
-                        return_value=mock_hub,
-                    )
+            mock_hub_class = stack.enter_context(
+                patch(
+                    "pybricksdev.connections.pybricks.PybricksHubUSB",
+                    return_value=mock_hub,
                 )
-                stack.enter_context(patch("usb.core.find", return_value="mock_device"))
+            )
+            stack.enter_context(patch("usb.core.find", return_value="mock_device"))
 
-                # Run the command
-                download = Download()
-                await download.run(args)
+            # Run the command
+            download = Download()
+            await download.run(args)
 
-                # Verify the hub was created and used correctly
-                mock_hub_class.assert_called_once_with("mock_device")
-                mock_hub.connect.assert_called_once()
-                mock_hub.download.assert_called_once()
-                mock_hub.disconnect.assert_called_once()
-        finally:
-            os.unlink(temp_path)
+            # Verify the hub was created and used correctly
+            mock_hub_class.assert_called_once_with("mock_device")
+            mock_hub.connect.assert_called_once()
+            mock_hub.download.assert_called_once()
+            mock_hub.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_download_ssh(self):
@@ -154,12 +154,16 @@ class TestDownload:
         mock_hub = AsyncMock()
         mock_hub.download = AsyncMock()
 
-        # Create a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+        # Set up mocks using ExitStack
+        with contextlib.ExitStack() as stack:
+            # Create and manage temporary file
+            temp = stack.enter_context(
+                tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False)
+            )
             temp.write("print('test')")
             temp_path = temp.name
+            stack.callback(os.unlink, temp_path)
 
-        try:
             # Create args
             args = argparse.Namespace(
                 conntype="ssh",
@@ -167,39 +171,39 @@ class TestDownload:
                 name="ev3dev.local",
             )
 
-            # Set up mocks using ExitStack
-            with contextlib.ExitStack() as stack:
-                mock_hub_class = stack.enter_context(
-                    patch(
-                        "pybricksdev.connections.ev3dev.EV3Connection",
-                        return_value=mock_hub,
-                    )
+            mock_hub_class = stack.enter_context(
+                patch(
+                    "pybricksdev.connections.ev3dev.EV3Connection",
+                    return_value=mock_hub,
                 )
-                stack.enter_context(
-                    patch("socket.gethostbyname", return_value="192.168.1.1")
-                )
+            )
+            stack.enter_context(
+                patch("socket.gethostbyname", return_value="192.168.1.1")
+            )
 
-                # Run the command
-                download = Download()
-                await download.run(args)
+            # Run the command
+            download = Download()
+            await download.run(args)
 
-                # Verify the hub was created and used correctly
-                mock_hub_class.assert_called_once_with("192.168.1.1")
-                mock_hub.connect.assert_called_once()
-                mock_hub.download.assert_called_once()
-                mock_hub.disconnect.assert_called_once()
-        finally:
-            os.unlink(temp_path)
+            # Verify the hub was created and used correctly
+            mock_hub_class.assert_called_once_with("192.168.1.1")
+            mock_hub.connect.assert_called_once()
+            mock_hub.download.assert_called_once()
+            mock_hub.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_download_ssh_no_name(self):
         """Test that SSH connection requires a name."""
-        # Create a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+        # Set up mocks using ExitStack
+        with contextlib.ExitStack() as stack:
+            # Create and manage temporary file
+            temp = stack.enter_context(
+                tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False)
+            )
             temp.write("print('test')")
             temp_path = temp.name
+            stack.callback(os.unlink, temp_path)
 
-        try:
             # Create args without name
             args = argparse.Namespace(
                 conntype="ssh",
@@ -211,8 +215,6 @@ class TestDownload:
             download = Download()
             with pytest.raises(SystemExit, match="1"):
                 await download.run(args)
-        finally:
-            os.unlink(temp_path)
 
     @pytest.mark.asyncio
     async def test_download_stdin(self):
@@ -265,12 +267,16 @@ class TestDownload:
         mock_hub = AsyncMock()
         mock_hub.connect.side_effect = RuntimeError("Connection failed")
 
-        # Create a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
+        # Set up mocks using ExitStack
+        with contextlib.ExitStack() as stack:
+            # Create and manage temporary file
+            temp = stack.enter_context(
+                tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False)
+            )
             temp.write("print('test')")
             temp_path = temp.name
+            stack.callback(os.unlink, temp_path)
 
-        try:
             # Create args
             args = argparse.Namespace(
                 conntype="ble",
@@ -278,24 +284,20 @@ class TestDownload:
                 name="MyHub",
             )
 
-            # Set up mocks using ExitStack
-            with contextlib.ExitStack() as stack:
-                stack.enter_context(
-                    patch(
-                        "pybricksdev.connections.pybricks.PybricksHubBLE",
-                        return_value=mock_hub,
-                    )
+            stack.enter_context(
+                patch(
+                    "pybricksdev.connections.pybricks.PybricksHubBLE",
+                    return_value=mock_hub,
                 )
-                stack.enter_context(
-                    patch("pybricksdev.ble.find_device", return_value="mock_device")
-                )
+            )
+            stack.enter_context(
+                patch("pybricksdev.ble.find_device", return_value="mock_device")
+            )
 
-                # Run the command and verify it raises the error
-                download = Download()
-                with pytest.raises(RuntimeError, match="Connection failed"):
-                    await download.run(args)
+            # Run the command and verify it raises the error
+            download = Download()
+            with pytest.raises(RuntimeError, match="Connection failed"):
+                await download.run(args)
 
-                # Verify disconnect was not called since connection failed
-                mock_hub.disconnect.assert_not_called()
-        finally:
-            os.unlink(temp_path)
+            # Verify disconnect was not called since connection failed
+            mock_hub.disconnect.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,7 +64,7 @@ class TestDownload:
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub._mpy_abi_version = 6
-        mock_hub.download_user_program = AsyncMock()
+        mock_hub.download = AsyncMock()
 
         # Create a temporary file
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
@@ -79,27 +79,20 @@ class TestDownload:
                 name="MyHub",
             )
 
-            # Mock the compilation
-            mock_mpy = MagicMock()
-            mock_mpy.__bytes__ = lambda self: b"compiled code"
-
             # Mock the hub creation
             with patch(
                 "pybricksdev.connections.pybricks.PybricksHubBLE", return_value=mock_hub
             ) as mock_hub_class:
                 with patch("pybricksdev.ble.find_device", return_value="mock_device"):
-                    with patch(
-                        "pybricksdev.compile.compile_multi_file", return_value=mock_mpy
-                    ):
-                        # Run the command
-                        download = Download()
-                        await download.run(args)
+                    # Run the command
+                    download = Download()
+                    await download.run(args)
 
-                        # Verify the hub was created and used correctly
-                        mock_hub_class.assert_called_once_with("mock_device")
-                        mock_hub.connect.assert_called_once()
-                        mock_hub.download_user_program.assert_called_once()
-                        mock_hub.disconnect.assert_called_once()
+                    # Verify the hub was created and used correctly
+                    mock_hub_class.assert_called_once_with("mock_device")
+                    mock_hub.connect.assert_called_once()
+                    mock_hub.download.assert_called_once()
+                    mock_hub.disconnect.assert_called_once()
         finally:
             os.unlink(temp_path)
 
@@ -109,7 +102,7 @@ class TestDownload:
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub._mpy_abi_version = 6
-        mock_hub.download_user_program = AsyncMock()
+        mock_hub.download = AsyncMock()
 
         # Create a temporary file
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
@@ -124,27 +117,20 @@ class TestDownload:
                 name=None,
             )
 
-            # Mock the compilation
-            mock_mpy = MagicMock()
-            mock_mpy.__bytes__ = lambda self: b"compiled code"
-
             # Mock the hub creation
             with patch(
                 "pybricksdev.connections.pybricks.PybricksHubUSB", return_value=mock_hub
             ) as mock_hub_class:
                 with patch("usb.core.find", return_value="mock_device"):
-                    with patch(
-                        "pybricksdev.compile.compile_multi_file", return_value=mock_mpy
-                    ):
-                        # Run the command
-                        download = Download()
-                        await download.run(args)
+                    # Run the command
+                    download = Download()
+                    await download.run(args)
 
-                        # Verify the hub was created and used correctly
-                        mock_hub_class.assert_called_once_with("mock_device")
-                        mock_hub.connect.assert_called_once()
-                        mock_hub.download_user_program.assert_called_once()
-                        mock_hub.disconnect.assert_called_once()
+                    # Verify the hub was created and used correctly
+                    mock_hub_class.assert_called_once_with("mock_device")
+                    mock_hub.connect.assert_called_once()
+                    mock_hub.download.assert_called_once()
+                    mock_hub.disconnect.assert_called_once()
         finally:
             os.unlink(temp_path)
 
@@ -214,7 +200,7 @@ class TestDownload:
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub._mpy_abi_version = 6
-        mock_hub.download_user_program = AsyncMock()
+        mock_hub.download = AsyncMock()
 
         # Create a mock stdin
         mock_stdin = io.StringIO("print('test')")
@@ -228,31 +214,22 @@ class TestDownload:
             name="MyHub",
         )
 
-        # Mock the compilation
-        mock_mpy = MagicMock()
-        mock_mpy.__bytes__ = lambda self: b"compiled code"
-
         # Mock the hub creation and file handling
         with patch(
             "pybricksdev.connections.pybricks.PybricksHubBLE", return_value=mock_hub
         ) as mock_hub_class:
             with patch("pybricksdev.ble.find_device", return_value="mock_device"):
-                with patch(
-                    "pybricksdev.compile.compile_multi_file", return_value=mock_mpy
-                ):
-                    with patch("tempfile.NamedTemporaryFile") as mock_temp:
-                        mock_temp.return_value.__enter__.return_value.name = (
-                            "/tmp/test.py"
-                        )
-                        # Run the command
-                        download = Download()
-                        await download.run(args)
+                with patch("tempfile.NamedTemporaryFile") as mock_temp:
+                    mock_temp.return_value.__enter__.return_value.name = "/tmp/test.py"
+                    # Run the command
+                    download = Download()
+                    await download.run(args)
 
-                        # Verify the hub was created and used correctly
-                        mock_hub_class.assert_called_once_with("mock_device")
-                        mock_hub.connect.assert_called_once()
-                        mock_hub.download_user_program.assert_called_once()
-                        mock_hub.disconnect.assert_called_once()
+                    # Verify the hub was created and used correctly
+                    mock_hub_class.assert_called_once_with("mock_device")
+                    mock_hub.connect.assert_called_once()
+                    mock_hub.download.assert_called_once()
+                    mock_hub.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_download_connection_error(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 
-from pybricksdev.cli import Push, Tool
+from pybricksdev.cli import Download, Tool
 
 
 class TestTool:
@@ -20,8 +20,8 @@ class TestTool:
             Tool()
 
 
-class TestPush:
-    """Tests for the Push command."""
+class TestDownload:
+    """Tests for the Download command."""
 
     def test_add_parser(self):
         """Test that the parser is set up correctly."""
@@ -29,14 +29,14 @@ class TestPush:
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
 
-        # Add the push command
-        push = Push()
-        push.add_parser(subparsers)
+        # Add the download command
+        download = Download()
+        download.add_parser(subparsers)
 
         # Verify the parser was created with correct arguments
-        assert "push" in subparsers.choices
-        parser = subparsers.choices["push"]
-        assert parser.tool is push
+        assert "download" in subparsers.choices
+        parser = subparsers.choices["download"]
+        assert parser.tool is download
 
         # Test that required arguments are present
         mock_file = mock_open(read_data="print('test')")
@@ -59,8 +59,8 @@ class TestPush:
             parser.parse_args(["invalid", "test.py"])
 
     @pytest.mark.asyncio
-    async def test_push_ble(self):
-        """Test running the push command with BLE connection."""
+    async def test_download_ble(self):
+        """Test running the download command with BLE connection."""
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub._mpy_abi_version = 6
@@ -92,8 +92,8 @@ class TestPush:
                         "pybricksdev.compile.compile_multi_file", return_value=mock_mpy
                     ):
                         # Run the command
-                        push = Push()
-                        await push.run(args)
+                        download = Download()
+                        await download.run(args)
 
                         # Verify the hub was created and used correctly
                         mock_hub_class.assert_called_once_with("mock_device")
@@ -104,8 +104,8 @@ class TestPush:
             os.unlink(temp_path)
 
     @pytest.mark.asyncio
-    async def test_push_usb(self):
-        """Test running the push command with USB connection."""
+    async def test_download_usb(self):
+        """Test running the download command with USB connection."""
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub._mpy_abi_version = 6
@@ -137,8 +137,8 @@ class TestPush:
                         "pybricksdev.compile.compile_multi_file", return_value=mock_mpy
                     ):
                         # Run the command
-                        push = Push()
-                        await push.run(args)
+                        download = Download()
+                        await download.run(args)
 
                         # Verify the hub was created and used correctly
                         mock_hub_class.assert_called_once_with("mock_device")
@@ -149,8 +149,8 @@ class TestPush:
             os.unlink(temp_path)
 
     @pytest.mark.asyncio
-    async def test_push_ssh(self):
-        """Test running the push command with SSH connection."""
+    async def test_download_ssh(self):
+        """Test running the download command with SSH connection."""
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub.download = AsyncMock()
@@ -174,8 +174,8 @@ class TestPush:
             ) as mock_hub_class:
                 with patch("socket.gethostbyname", return_value="192.168.1.1"):
                     # Run the command
-                    push = Push()
-                    await push.run(args)
+                    download = Download()
+                    await download.run(args)
 
                     # Verify the hub was created and used correctly
                     mock_hub_class.assert_called_once_with("192.168.1.1")
@@ -186,7 +186,7 @@ class TestPush:
             os.unlink(temp_path)
 
     @pytest.mark.asyncio
-    async def test_push_ssh_no_name(self):
+    async def test_download_ssh_no_name(self):
         """Test that SSH connection requires a name."""
         # Create a temporary file
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as temp:
@@ -202,15 +202,15 @@ class TestPush:
             )
 
             # Run the command and verify it exits
-            push = Push()
+            download = Download()
             with pytest.raises(SystemExit, match="1"):
-                await push.run(args)
+                await download.run(args)
         finally:
             os.unlink(temp_path)
 
     @pytest.mark.asyncio
-    async def test_push_stdin(self):
-        """Test running the push command with stdin input."""
+    async def test_download_stdin(self):
+        """Test running the download command with stdin input."""
         # Create a mock hub
         mock_hub = AsyncMock()
         mock_hub._mpy_abi_version = 6
@@ -245,8 +245,8 @@ class TestPush:
                             "/tmp/test.py"
                         )
                         # Run the command
-                        push = Push()
-                        await push.run(args)
+                        download = Download()
+                        await download.run(args)
 
                         # Verify the hub was created and used correctly
                         mock_hub_class.assert_called_once_with("mock_device")
@@ -255,7 +255,7 @@ class TestPush:
                         mock_hub.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_push_connection_error(self):
+    async def test_download_connection_error(self):
         """Test handling connection errors."""
         # Create a mock hub that raises an error during connect
         mock_hub = AsyncMock()
@@ -287,9 +287,9 @@ class TestPush:
                         "pybricksdev.compile.compile_multi_file", return_value=mock_mpy
                     ):
                         # Run the command and verify it raises the error
-                        push = Push()
+                        download = Download()
                         with pytest.raises(RuntimeError, match="Connection failed"):
-                            await push.run(args)
+                            await download.run(args)
 
                         # Verify disconnect was not called since connection failed
                         mock_hub.disconnect.assert_not_called()


### PR DESCRIPTION
Sometimes, it's useful to upload the program to hubs without running it, especially when hubs are in complex environments and require manual start for safety and convenience purposes.

Let me know if this makes sense. Thanks.