### PR TITLE
Fix: Correct ValueError message for invalid ABI version

### DIFF
--- a/pybricksdev/compile.py
+++ b/pybricksdev/compile.py
@@ -74,7 +74,7 @@ async def compile_file(
                 ),
             )
         else:
-            raise ValueError("mpy_version must be 5")
+            raise ValueError("mpy_version must be 5 or 6")
 
         proc.check_returncode()
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -31,3 +31,18 @@ async def test_compile_file(abi: int):
             assert int_bits == 31
         finally:
             os.unlink(f.name)
+
+
+@pytest.mark.asyncio
+async def test_compile_file_invalid_abi():
+    with NamedTemporaryFile("w", delete=False) as f:
+        try:
+            f.write("print('test')")
+            f.close()
+
+            with pytest.raises(ValueError, match="mpy_version must be 5 or 6"):
+                await compile_file(
+                    os.path.dirname(f.name), os.path.basename(f.name), abi=4
+                )
+        finally:
+            os.unlink(f.name)


### PR DESCRIPTION
The error message raised in `pybricksdev.compile.compile_file` when an unsupported ABI version was provided incorrectly stated "mpy_version must be 5". This has been corrected to "mpy_version must be 5 or 6" to accurately reflect the supported ABI versions.

A new test case (`test_compile_file_invalid_abi`) has been added to `tests/test_compile.py` to verify that the correct ValueError and message are raised for invalid ABI versions.