### PR TITLE
pybricksdev.connections.pybricks: Set callback before sending subscribe

### DIFF
--- a/pybricksdev/connections/pybricks.py
+++ b/pybricksdev/connections/pybricks.py
@@ -947,8 +947,8 @@ class PybricksHubUSB(PybricksHub):
         await self._send_message(bytes([PybricksUsbOutEpMessageType.COMMAND]) + data)
 
     async def start_notify(self, uuid: str, callback: Callable) -> None:
-        await self._send_message(bytes([PybricksUsbOutEpMessageType.SUBSCRIBE, 1]))
         self._notify_callbacks[uuid] = callback
+        await self._send_message(bytes([PybricksUsbOutEpMessageType.SUBSCRIBE, 1]))
 
     async def _monitor_usb(self):
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
This makes sure that the initial status update will be handled and not dropped. This message contains important information such as the currently active program slot.

See this comment: https://github.com/pybricks/support/issues/2306#issuecomment-3155928778

Appears to fix https://github.com/pybricks/support/issues/2306