### PR TITLE
cli: Fix piping .py file from stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed piping text files to `pybricksdev run` from stdin.
+
 ## [2.0.0] - 2025-08-10
 
 ### Added

--- a/pybricksdev/cli/__init__.py
+++ b/pybricksdev/cli/__init__.py
@@ -68,9 +68,7 @@ def _get_script_path(file: TextIO) -> ContextManager[PathLike]:
         @contextlib.contextmanager
         def temp_context():
             try:
-                with NamedTemporaryFile(
-                    suffix=".py", delete=False, encoding="utf-8"
-                ) as temp:
+                with NamedTemporaryFile("wb", suffix=".py", delete=False) as temp:
                     temp.write(file.buffer.read())
 
                 yield temp.name


### PR DESCRIPTION
When we fixed explicit text encoding for text files, we accidentally changed one NamedTemporaryFile to text mode. Change it back to binary mode.

Fixes: https://github.com/pybricks/support/issues/2325